### PR TITLE
Support async context manager on GraphClient

### DIFF
--- a/core/graph_1_1_0/main.py
+++ b/core/graph_1_1_0/main.py
@@ -39,6 +39,14 @@ class GraphClient:
         self.client = httpx.AsyncClient()
         self._access_token = None
         self._token_expiry = None
+
+    async def __aenter__(self) -> "GraphClient":
+        """Enter the async context manager and return self."""
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        """Close the underlying HTTP client when exiting the context."""
+        await self.close()
         
     async def _get_access_token(self):
         """Get a valid access token, refreshing if necessary."""

--- a/tests/core/graph_1_1_0/test_graph_integration.py
+++ b/tests/core/graph_1_1_0/test_graph_integration.py
@@ -11,6 +11,7 @@ import dotenv
 import re
 from core.utils.config import config
 import httpx
+from unittest.mock import AsyncMock
 dotenv.load_dotenv()
 
 print("CLIENT_ID:", os.getenv("CLIENT_ID"))
@@ -196,4 +197,17 @@ def test_environment_variables():
     # Check that all required variables are set
     required_vars = ["client_id", "client_secret", "tenant_id"]
     if not all(config["azure"][k] for k in required_vars):
-        pytest.skip("Required environment variables not set") 
+        pytest.skip("Required environment variables not set")
+
+
+@pytest.mark.asyncio
+async def test_graphclient_context_manager_closes():
+    """GraphClient closes its AsyncClient when used as a context manager."""
+    client = GraphClient()
+    aclose_mock = AsyncMock()
+    client.client.aclose = aclose_mock
+
+    async with client as cm:
+        assert cm is client
+
+    aclose_mock.assert_awaited_once()

--- a/tests/core/processing_1_2_0/test_email_processor.py
+++ b/tests/core/processing_1_2_0/test_email_processor.py
@@ -28,7 +28,7 @@ async def test_email_processing_workflow():
     3. Save metadata
     """
     processor = EmailProcessor(config)
-    client = GraphClient()
+    async with GraphClient() as client:
     
     try:
         # Get a real message from OneDrive
@@ -102,7 +102,7 @@ async def test_email_processing_workflow():
 async def test_email_with_metadata():
     """Test processing an email with complete metadata using a real .eml file."""
     processor = EmailProcessor(config)
-    client = GraphClient()
+    async with GraphClient() as client:
     
     try:
         # Get a real message from OneDrive
@@ -159,9 +159,9 @@ async def test_email_with_metadata():
 async def test_filename_generation():
     """Test that filenames are generated correctly for real emails."""
     processor = EmailProcessor(config)
-    client = GraphClient()
-    
-    try:
+    async with GraphClient() as client:
+
+        try:
         # Get a real message from OneDrive
         user_email = config["user"]["email"]
         
@@ -191,7 +191,7 @@ async def test_filename_generation():
         processed_path = f"{processed_folder}/{result['filename']}"
         file_exists = await client.file_exists(processed_path)
         assert file_exists, f"Processed file not found at {processed_path}"
-        
+
     except Exception as e:
         pytest.fail(f"Filename generation test failed: {str(e)}")
     finally:


### PR DESCRIPTION
## Summary
- implement `__aenter__` and `__aexit__` for `GraphClient`
- update EmailProcessor tests to use context manager
- add unit test verifying the context manager closes the `AsyncClient`

## Testing
- `python scripts/check_structure.py` *(fails: Disallowed top-level items and import boundaries)*
- `python -m pytest -m "not slow"` *(fails: No module named pytest)*