### PR TITLE
Centralize logging setup

### DIFF
--- a/core/api_1_4_0/assistant.py
+++ b/core/api_1_4_0/assistant.py
@@ -1,11 +1,12 @@
 from dotenv import load_dotenv
 import os
 import logging
+from core.utils.logging import configure_logging
 from openai import OpenAI
 from typing import List, Optional
 
 # Configure logging
-logging.basicConfig(level=logging.INFO)
+configure_logging(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 # Load environment variables

--- a/core/api_1_4_0/main_FastApi.py
+++ b/core/api_1_4_0/main_FastApi.py
@@ -1,6 +1,7 @@
 from dotenv import load_dotenv
 import os, uuid, asyncio, openai
 import logging
+from core.utils.logging import configure_logging
 from fastapi import FastAPI, Header, HTTPException, Depends, status
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
@@ -9,7 +10,7 @@ from typing import Dict, Any, List, Optional, Union
 from .assistant import assistant_manager
 
 # Configure logging
-logging.basicConfig(level=logging.INFO)
+configure_logging(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 # Load environment variables

--- a/core/storage_1_3_0/vector_repository.py
+++ b/core/storage_1_3_0/vector_repository.py
@@ -2,6 +2,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional
 import asyncio
 import logging
+from core.utils.logging import configure_logging
 import os
 
 import orjson
@@ -175,7 +176,7 @@ class VectorRepository:
 
 async def main():
     """Main entry point for vector store operations."""
-    logging.basicConfig(level=logging.INFO)
+    configure_logging(level=logging.INFO)
     
     repo = VectorRepository()
     directory = config["onedrive"]["processed_emails_folder"]

--- a/core/utils/logging.py
+++ b/core/utils/logging.py
@@ -1,14 +1,27 @@
 import logging
+from typing import Optional
 
-# Configure logging
-logging.basicConfig(
-    level=logging.DEBUG,
-    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
-    handlers=[
-        logging.StreamHandler(),
-        logging.FileHandler('app.log')
-    ]
-)
+_configured = False
+
+def configure_logging(level: int = logging.DEBUG, filename: str = "app.log") -> None:
+    """Configure the root logger once.
+
+    Subsequent calls have no effect.
+
+    Args:
+        level: Logging level to use for the root logger.
+        filename: File to write logs to.
+    """
+    global _configured
+    if _configured:
+        return
+
+    logging.basicConfig(
+        level=level,
+        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+        handlers=[logging.StreamHandler(), logging.FileHandler(filename)],
+    )
+    _configured = True
 
 def get_logger(name):
     """Get a logger instance with the specified name.
@@ -19,4 +32,5 @@ def get_logger(name):
     Returns:
         A logger instance.
     """
+    configure_logging()
     return logging.getLogger(name)

--- a/tests/integration/storage_1_3_0/test_vector_store_integration.py
+++ b/tests/integration/storage_1_3_0/test_vector_store_integration.py
@@ -1,11 +1,12 @@
 import pytest
 import asyncio
 import logging
+from core.utils.logging import configure_logging
 from core.storage_1_3_0.vector_repository import VectorRepository
 from core.utils.config import config
 from core.utils.onedrive_utils import list_folder_contents
 
-logging.basicConfig(level=logging.INFO)
+configure_logging(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add `configure_logging` to core utils
- call `configure_logging` in modules previously using `logging.basicConfig`
- adjust integration test

## Testing
- `python scripts/check_structure.py`
- `python -m pytest -m "not slow"` *(fails: No module named pytest)*
- `black --check .` *(fails: many files would reformat)*